### PR TITLE
Fix code block formatting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ module that displays all data reported by lm-sensors
 
 * Installation script provided by [@subz390](https://github.com/subz390): 
 
-        wget https://github.com/ocristopfer/cockpit-sensors/releases/latest/download/cockpit-sensors.tar.xz && \
-        tar -xf cockpit-sensors.tar.xz cockpit-sensors/dist && \
-        mv cockpit-sensors/dist /usr/share/cockpit/sensors && \
-        rm -r cockpit-sensors && \
-        rm cockpit-sensors.tar.xz
+```shell
+wget https://github.com/ocristopfer/cockpit-sensors/releases/latest/download/cockpit-sensors.tar.xz && \
+  tar -xf cockpit-sensors.tar.xz cockpit-sensors/dist && \
+  mv cockpit-sensors/dist /usr/share/cockpit/sensors && \
+  rm -r cockpit-sensors && \
+  rm cockpit-sensors.tar.xz
+```
 
 * .deb package:
 https://github.com/ocristopfer/cockpit-sensors/releases/latest/download/cockpit-sensors.deb


### PR DESCRIPTION
Minor fix just to correct the code block formatting in the readme.

It previously contained indentation which would mean anyone doing a copy/pasta would result in the commands not being included in the shell history.

Update the code block to be properly fenced in backticks as per markdown formatting best practices.