### PR TITLE
Add quotes to undefined check

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -98,7 +98,7 @@ export class Application extends React.Component {
     };
 
     setIcon = (name) => {
-        if(typeof name != undefined){
+        if(typeof name != 'undefined'){
             if (name.includes('fan')) {
                 return <FanIcon size='md' />;
             }
@@ -166,7 +166,7 @@ export class Application extends React.Component {
     };
 
     adjustValue = (name, value) => {
-        if(typeof name != undefined){
+        if(typeof name != 'undefined'){
             if (name.includes('temp')) {
                 return this.state.fahrenheitChecked
                     ? parseFloat((value * 9 / 5) + 32).toFixed(1)


### PR DESCRIPTION
Minor addition to the undefined fix to allow it to work properly for the `Cannot read properties of undefined (reading 'includes')` bug.

typeof returns a string so changed the check to use the string `'undefined'` rather than the value.